### PR TITLE
Refine LOGGER_TYPES

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ cmake --install build
 int main() {
     // Log with different levels and categories
     tt::log_info(tt::LogDevice, "Device message");
-    tt::log_debug(tt::LogModel, "Model debug message");
+    tt::log_debug(tt::LogOp, "Op debug message");
     tt::log_warning(tt::LogLLRuntime, "Runtime warning");
     tt::log_error(tt::LogDevice, "Device error");
-    tt::log_critical(tt::LogModel, "Model critical error");
+    tt::log_critical(tt::LogOp, "Op critical error");
 
     // Log with format strings
     tt::log_info(tt::LogDevice, "Device {} message", 123);
-    tt::log_info(tt::LogModel, "Model {} with {} parameters", "test", 42);
+    tt::log_info(tt::LogOp, "Op {} with {} parameters", "test", 42);
 
     // Log with default category (LogAlways)
     tt::log_info("Default category message");
@@ -101,31 +101,26 @@ int main() {
 ```
 
 ## Available Categories
-To be refined
+The following log categories are available:
 
 - Always
 - Test
 - Timer
 - Device
-- Model
 - LLRuntime
 - Loader
-- IO
-- CompileTrisc
 - BuildKernels
 - Verif
-- Golden
 - Op
-- HLK
-- HLKC
-- Reportify
-- GraphCompiler
 - Dispatch
 - Fabric
 - Metal
+- TTNN
 - MetalTrace
 - SiliconDriver
 - EmulationDriver
+
+Each category is prefixed with "Log" when used in code (e.g., `tt::LogDevice`, `tt::LogOp`).
 
 ## CMake Integration
 

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -13,44 +13,39 @@
 #include <string_view>
 #include <utility>
 
-#define LOGGER_TYPES \
+#ifndef TT_LOGGER_TYPES
+#define TT_LOGGER_TYPES \
     X(Always)        \
     X(Test)          \
     X(Timer)         \
     X(Device)        \
-    X(Model)         \
     X(LLRuntime)     \
     X(Loader)        \
-    X(IO)            \
-    X(CompileTrisc)  \
     X(BuildKernels)  \
     X(Verif)         \
-    X(Golden)        \
     X(Op)            \
-    X(HLK)           \
-    X(HLKC)          \
-    X(Reportify)     \
-    X(GraphCompiler) \
     X(Dispatch)      \
     X(Fabric)        \
     X(Metal)         \
+    X(TTNN)          \
     X(MetalTrace)    \
     X(SiliconDriver) \
     X(EmulationDriver)
+#endif
 
 namespace tt {
 
 // clang-format off
 enum LogType {
 #define X(a) Log ## a,
-    LOGGER_TYPES
+    TT_LOGGER_TYPES
 #undef X
 };
 // clang-format on
 
 constexpr std::array<const char *, std::size_t(LogType::LogEmulationDriver) + 1> log_type_names = {
 #define X(name) #name,
-    LOGGER_TYPES
+    TT_LOGGER_TYPES
 #undef X
 };
 
@@ -138,4 +133,4 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
     }
 };
 }  // namespace fmt
-#undef LOGGER_TYPES
+#undef TT_LOGGER_TYPES

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -92,8 +92,8 @@ TEST_CASE("Basic logging functionality", "[logger]") {
 
     SECTION("Debug") {
         spdlog::default_logger()->set_level(spdlog::level::debug);
-        tt::log_debug(tt::LogModel, "Model debug message");
-        soft_check_log_contains(sink.get(), "[Model] Model debug message");
+        tt::log_debug(tt::LogOp, "Model debug message");
+        soft_check_log_contains(sink.get(), "[Op] Model debug message");
     }
 
     SECTION("Warning") {
@@ -107,8 +107,8 @@ TEST_CASE("Basic logging functionality", "[logger]") {
     }
 
     SECTION("Critical") {
-        tt::log_critical(tt::LogModel, "Model critical error");
-        soft_check_log_contains(sink.get(), "[Model] Model critical error");
+        tt::log_critical(tt::LogOp, "Model critical error");
+        soft_check_log_contains(sink.get(), "[Op] Model critical error");
     }
 }
 
@@ -121,14 +121,14 @@ TEST_CASE("Format string functionality", "[logger]") {
     }
 
     SECTION("Multiple arguments") {
-        tt::log_info(tt::LogModel, "Model {} with {} parameters", "test", 42);
-        soft_check_log_contains(sink.get(), "[Model] Model test with 42 parameters");
+        tt::log_info(tt::LogOp, "Model {} with {} parameters", "test", 42);
+        soft_check_log_contains(sink.get(), "[Op] Model test with 42 parameters");
     }
 
     SECTION("Filesystem path formatting") {
         std::filesystem::path p = "/usr/bin/hello";
-        tt::log_info(tt::LogModel, "Path: {}", p);
-        soft_check_log_contains(sink.get(), "[Model] Path: /usr/bin/hello");
+        tt::log_info(tt::LogOp, "Path: {}", p);
+        soft_check_log_contains(sink.get(), "[Op] Path: /usr/bin/hello");
     }
 }
 
@@ -173,7 +173,7 @@ TEST_CASE("Log level filtering", "[logger]") {
 
 TEST_CASE("Log type to string mapping", "[logger]") {
     REQUIRE(std::string(tt::logtype_to_string(tt::LogDevice)) == "Device");
-    REQUIRE(std::string(tt::logtype_to_string(tt::LogModel)) == "Model");
+    REQUIRE(std::string(tt::logtype_to_string(tt::LogOp)) == "Op");
     REQUIRE(std::string(tt::logtype_to_string(tt::LogLLRuntime)) == "LLRuntime");
 }
 
@@ -198,7 +198,7 @@ TEST_CASE("File logging functionality", "[logger]") {
 
         // Write some test logs
         tt::log_info(tt::LogDevice, "Device file message");
-        tt::log_warning(tt::LogModel, "Model file warning");
+        tt::log_warning(tt::LogOp, "Model file warning");
         tt::log_error(tt::LogLLRuntime, "Runtime file error");
 
         // Flush and close the logger
@@ -212,7 +212,7 @@ TEST_CASE("File logging functionality", "[logger]") {
         std::string file_contents = buffer.str();
 
         REQUIRE(file_contents.find("[Device] Device file message") != std::string::npos);
-        REQUIRE(file_contents.find("[Model] Model file warning") != std::string::npos);
+        REQUIRE(file_contents.find("[Op] Model file warning") != std::string::npos);
         REQUIRE(file_contents.find("[LLRuntime] Runtime file error") != std::string::npos);
 
         // Clean up


### PR DESCRIPTION
Remove unused logger types.

Guard with ifndef to allow clients to override.

Change name from LOGGER_TYPES to TT_LOGGER_TYPES to avoid collisions.