### PR TITLE
Add initializer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ include(GNUInstallDirs)
 
 include(cmake/CPM.cmake)
 if(NOT TARGET fmt::fmt-header-only)
-    CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
+    cpmaddpackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
 endif()
 
 if(NOT TARGET spdlog::spdlog_header_only)
-    CPMAddPackage(
+    cpmaddpackage(
         NAME spdlog
         GITHUB_REPOSITORY gabime/spdlog
         VERSION 1.15.2
@@ -30,7 +30,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
             FILE_SET api
             TYPE HEADERS
             BASE_DIRS ${CMAKE_INSTALL_INCLUDEDIR}
-            FILES ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/tt-logger.hpp
+            FILES
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/tt-logger.hpp
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/tt-logger-initializer.hpp
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,51 @@ int main() {
 }
 ```
 
+## Logger Initialization
+
+The `LoggerInitializer` class provides a convenient way to set up the logging system with either file-based or console-based logging. It supports configuration through environment variables.
+
+### Basic Usage
+
+```cpp
+#include <tt-logger/tt-logger-initializer.hpp>
+
+int main() {
+    // Initialize logger with default environment variables
+    tt::LoggerInitializer logger_init;
+
+    // Now you can use the logging functions
+    tt::log_info("Logger initialized");
+    return 0;
+}
+```
+
+### Environment Variables
+
+The `LoggerInitializer` can be configured using the following environment variables:
+
+- `TT_LOGGER_FILE`: Path to the log file. If not set or empty, logs will be written to stdout.
+- `TT_LOGGER_LEVEL`: Log level (trace, debug, info, warning, error, critical). Defaults to "info" if not set.
+
+Example:
+```bash
+# Log to a file with debug level
+export TT_LOGGER_FILE=/path/to/logfile.log
+export TT_LOGGER_LEVEL=debug
+
+# Log to stdout with warning level
+export TT_LOGGER_LEVEL=warning
+```
+
+### Custom Environment Variable Names
+
+You can also specify custom environment variable names when creating the initializer:
+
+```cpp
+// Use custom environment variable names
+tt::LoggerInitializer logger_init("CUSTOM_LOG_FILE", "CUSTOM_LOG_LEVEL");
+```
+
 ## Available Categories
 The following log categories are available:
 

--- a/include/tt-logger/tt-logger-initializer.hpp
+++ b/include/tt-logger/tt-logger-initializer.hpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file tt-logger-initializer.hpp
+ * @brief Header file for the TT Logger initialization system
+ *
+ * This file contains the LoggerInitializer class which handles the setup and configuration
+ * of the logging system using spdlog. It provides functionality for both file-based and
+ * console-based logging with environment variable configuration support.
+ */
+
+#pragma once
+
+#include <spdlog/cfg/env.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+namespace tt {
+
+/**
+ * @brief Initializes and configures the logging system
+ *
+ * This class handles the setup of spdlog with either file-based or console-based logging.
+ * It supports configuration through environment variables.
+ */
+class LoggerInitializer {
+  private:
+    std::shared_ptr<spdlog::sinks::sink> create_sink(const std::string & file_path) {
+        if (file_path.empty()) {
+            return std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+        }
+
+        auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(file_path, true);
+        if (!sink) {
+            std::fprintf(stderr, "tt-logger failed to create log file '%s'\n", file_path.c_str());
+            std::abort();
+        }
+        return sink;
+    }
+
+    void configure_logger(std::shared_ptr<spdlog::sinks::sink> sink) {
+        auto logger = std::make_shared<spdlog::logger>("", sink);
+        spdlog::set_default_logger(logger);
+        spdlog::flush_on(spdlog::level::err);
+    }
+
+  public:
+    /**
+     * @brief Constructs a LoggerInitializer with environment variable configuration
+     *
+     * @param file_env Environment variable name for log file path
+     * @param level_env Environment variable name for log level
+     */
+    LoggerInitializer(std::string file_env = "TT_LOGGER_FILE", std::string level_env = "TT_LOGGER_LEVEL") noexcept {
+        const char * file_path = std::getenv(file_env.c_str());
+        auto         sink      = create_sink(file_path ? file_path : "");
+        configure_logger(sink);
+        spdlog::cfg::load_env_levels(level_env.c_str());  // Defaults to "info" if no ENV var set
+    }
+};
+
+}  // namespace tt

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @file tt-logger.hpp
+ * @brief A logging utility header that provides type-safe logging functionality with different log levels and categories.
+ */
+
 #pragma once
 
 #include <fmt/format.h>
@@ -35,6 +40,12 @@
 
 namespace tt {
 
+/**
+ * @brief Enumeration of different log categories/types supported by the logger.
+ *
+ * Each type represents a different component or subsystem that can be logged.
+ * The types are defined using the TT_LOGGER_TYPES macro for easy extension.
+ */
 // clang-format off
 enum LogType {
 #define X(a) Log ## a,
@@ -43,89 +54,200 @@ enum LogType {
 };
 // clang-format on
 
+/**
+ * @brief Array containing string representations of all log types.
+ *
+ * The array is indexed by the LogType enum values and contains the corresponding
+ * string names for each log type.
+ */
 constexpr std::array<const char *, std::size_t(LogType::LogEmulationDriver) + 1> log_type_names = {
 #define X(name) #name,
     TT_LOGGER_TYPES
 #undef X
 };
 
+/**
+ * @brief Converts a LogType enum value to its string representation.
+ *
+ * @param logtype The LogType enum value to convert
+ * @return const char* The string representation of the log type
+ */
 constexpr const char * logtype_to_string(LogType logtype) noexcept {
     return static_cast<std::size_t>(logtype) < log_type_names.size() ?
                log_type_names[static_cast<std::size_t>(logtype)] :
                "UnknownType";
 }
 
-// log_trace
+/**
+ * @brief Logs a trace level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_trace(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     if (spdlog::should_log(spdlog::level::trace)) {
         spdlog::trace("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
     }
 }
 
+/**
+ * @brief Logs a trace level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_trace(fmt::format_string<Args...> fmt, Args &&... args) {
     log_trace(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
-// log_debug
+/**
+ * @brief Logs a debug level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_debug(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     if (spdlog::should_log(spdlog::level::debug)) {
         spdlog::debug("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
     }
 }
 
+/**
+ * @brief Logs a debug level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_debug(fmt::format_string<Args...> fmt, Args &&... args) {
     log_debug(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
-// log_info
+/**
+ * @brief Logs an info level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_info(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     spdlog::info("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
 }
 
+/**
+ * @brief Logs an info level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_info(fmt::format_string<Args...> fmt, Args &&... args) {
     log_info(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
-// log_warning
+/**
+ * @brief Logs a warning level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_warning(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     spdlog::warn("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
 }
 
+/**
+ * @brief Logs a warning level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_warning(fmt::format_string<Args...> fmt, Args &&... args) {
     log_warning(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
-// log_critical
+/**
+ * @brief Logs a critical level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_critical(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
 }
 
+/**
+ * @brief Logs a critical level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_critical(fmt::format_string<Args...> fmt, Args &&... args) {
     log_critical(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
-// log_fatal
+/**
+ * @brief Logs a fatal level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_fatal(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
 }
 
-// Without LogType (defaults to LogAlways)
+/**
+ * @brief Logs a fatal level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_fatal(fmt::format_string<Args...> fmt, Args &&... args) {
     log_fatal(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
-// log_error
+/**
+ * @brief Logs an error level message with a specific log type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param type The log type/category
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_error(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     spdlog::error("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
 }
 
+/**
+ * @brief Logs an error level message with default LogAlways type.
+ *
+ * @tparam Args Variadic template parameter for format arguments
+ * @param fmt The format string
+ * @param args The format arguments
+ */
 template <typename... Args> inline void log_error(fmt::format_string<Args...> fmt, Args &&... args) {
     log_error(LogType::LogAlways, fmt, std::forward<Args>(args)...);
 }
 
 }  // namespace tt
 
-// Custom formatter for LogType
+/**
+ * @brief Custom formatter for tt::LogType to enable formatting in fmt library.
+ */
 namespace fmt {
 template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
     template <typename FormatContext> constexpr auto format(tt::LogType logtype, FormatContext & ctx) const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,20 @@
 include(${PROJECT_SOURCE_DIR}/cmake/CPM.cmake)
-CPMAddPackage("gh:catchorg/Catch2@3.4.0")
+cpmaddpackage("gh:catchorg/Catch2@3.4.0")
 
 add_executable(${PROJECT_NAME}-test ${PROJECT_NAME}-test.cpp)
 
 target_link_libraries(
     ${PROJECT_NAME}-test
-    PRIVATE
-        ${PROJECT_NAME}::${PROJECT_NAME}
-        Catch2::Catch2WithMain
+    PRIVATE ${PROJECT_NAME}::${PROJECT_NAME} Catch2::Catch2WithMain
+)
+
+add_executable(
+    ${PROJECT_NAME}-initializer-test
+    ${PROJECT_NAME}-initializer-test.cpp
+)
+target_link_libraries(
+    ${PROJECT_NAME}-initializer-test
+    PRIVATE ${PROJECT_NAME}::${PROJECT_NAME}
 )
 
 include(CTest)

--- a/tests/tt-logger-initializer-test.cpp
+++ b/tests/tt-logger-initializer-test.cpp
@@ -1,0 +1,30 @@
+/**
+ * @file test_logger_initializer.cpp
+ * @brief Test file for the TT Logger initialization and basic logging functionality
+ *
+ * This test file demonstrates the usage of the TT Logger system, including:
+ * - Logger initialization using environment variables
+ * - Basic logging functionality across all log levels (trace through critical)
+ *
+ * @note Requires setting the environment variable TT_METAL_LOGGER_LEVEL=debug before running
+ */
+
+#include <tt-logger/tt-logger-initializer.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+using namespace tt;
+
+// Static logger initialization
+static LoggerInitializer _logger("TT_METAL_LOGGER_FILE", "TT_METAL_LOGGER_LEVEL");
+
+int main() {
+    // Test using tt-logger macros
+    log_trace("This is a trace message");
+    log_debug("This is a debug message");
+    log_info("This is an info message");
+    log_warning("This is a warning message");
+    log_error("This is an error message");
+    log_critical("This is a critical message");
+
+    return 0;
+}

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -2,6 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @file tt-logger-test.cpp
+ * @brief Test suite for the tt-logger library
+ *
+ * This file contains comprehensive unit tests for the tt-logger library, including:
+ * - Basic logging functionality (info, debug, warning, error, critical)
+ * - Format string functionality with various argument types
+ * - Log level filtering and type mapping
+ * - File logging capabilities
+ * - Performance testing for logging operations
+ *
+ * The tests use Catch2 framework and include custom sink implementations for testing.
+ */
+
 #include <fmt/std.h>  // needed for filesystem::path formatting
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/basic_file_sink.h>


### PR DESCRIPTION
Need a way to allow clients to configure log level, and perhaps logging to a file.

Add support by providing optional initializer in a header file.

Nothing stops a client from rolling a custom init.