### PR TITLE
Add support for source location, and variable pattern

### DIFF
--- a/include/tt-logger/tt-logger-initializer.hpp
+++ b/include/tt-logger/tt-logger-initializer.hpp
@@ -45,9 +45,12 @@ class LoggerInitializer {
         return sink;
     }
 
-    void configure_logger(std::shared_ptr<spdlog::sinks::sink> sink) {
+    void configure_logger(std::shared_ptr<spdlog::sinks::sink> sink, const std::string & pattern) {
         auto logger = std::make_shared<spdlog::logger>("", sink);
         spdlog::set_default_logger(logger);
+        if (!pattern.empty()) {
+            spdlog::set_pattern(pattern);
+        }
         spdlog::flush_on(spdlog::level::err);
     }
 
@@ -57,11 +60,13 @@ class LoggerInitializer {
      *
      * @param file_env Environment variable name for log file path
      * @param level_env Environment variable name for log level
+     * @param pattern The pattern string to use for log formatting
      */
-    LoggerInitializer(std::string file_env = "TT_LOGGER_FILE", std::string level_env = "TT_LOGGER_LEVEL") noexcept {
+    LoggerInitializer(std::string file_env = "TT_LOGGER_FILE", std::string level_env = "TT_LOGGER_LEVEL",
+                      std::string pattern = "") noexcept {
         const char * file_path = std::getenv(file_env.c_str());
         auto         sink      = create_sink(file_path ? file_path : "");
-        configure_logger(sink);
+        configure_logger(sink, pattern);
         spdlog::cfg::load_env_levels(level_env.c_str());  // Defaults to "info" if no ENV var set
     }
 };

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -88,7 +88,8 @@ constexpr const char * logtype_to_string(LogType logtype) noexcept {
  */
 template <typename... Args> inline void log_trace(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     if (spdlog::should_log(spdlog::level::trace)) {
-        spdlog::trace("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+        spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::trace, "[{}] {}", type,
+                    fmt::format(fmt, std::forward<Args>(args)...));
     }
 }
 
@@ -113,7 +114,8 @@ template <typename... Args> inline void log_trace(fmt::format_string<Args...> fm
  */
 template <typename... Args> inline void log_debug(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
     if (spdlog::should_log(spdlog::level::debug)) {
-        spdlog::debug("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+        spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::debug, "[{}] {}", type,
+                    fmt::format(fmt, std::forward<Args>(args)...));
     }
 }
 
@@ -137,7 +139,8 @@ template <typename... Args> inline void log_debug(fmt::format_string<Args...> fm
  * @param args The format arguments
  */
 template <typename... Args> inline void log_info(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::info("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+    spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::info, "[{}] {}", type,
+                fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 /**
@@ -160,7 +163,8 @@ template <typename... Args> inline void log_info(fmt::format_string<Args...> fmt
  * @param args The format arguments
  */
 template <typename... Args> inline void log_warning(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::warn("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+    spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::warn, "[{}] {}", type,
+                fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 /**
@@ -183,7 +187,8 @@ template <typename... Args> inline void log_warning(fmt::format_string<Args...> 
  * @param args The format arguments
  */
 template <typename... Args> inline void log_critical(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+    spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, "[{}] {}", type,
+                fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 /**
@@ -206,7 +211,8 @@ template <typename... Args> inline void log_critical(fmt::format_string<Args...>
  * @param args The format arguments
  */
 template <typename... Args> inline void log_fatal(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+    spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, "[{}] {}", type,
+                fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 /**
@@ -229,7 +235,8 @@ template <typename... Args> inline void log_fatal(fmt::format_string<Args...> fm
  * @param args The format arguments
  */
 template <typename... Args> inline void log_error(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::error("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+    spdlog::log(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::err, "[{}] {}", type,
+                fmt::format(fmt, std::forward<Args>(args)...));
 }
 
 /**

--- a/tests/tt-logger-initializer-test.cpp
+++ b/tests/tt-logger-initializer-test.cpp
@@ -15,7 +15,11 @@
 using namespace tt;
 
 // Static logger initialization
-static LoggerInitializer _logger("TT_METAL_LOGGER_FILE", "TT_METAL_LOGGER_LEVEL");
+constexpr auto env_file_var  = "TT_METAL_LOGGER_FILE";
+constexpr auto env_level_var = "TT_METAL_LOGGER_LEVEL";
+constexpr auto log_pattern   = "[%Y-%m-%d %H:%M:%S.%e] [%l] [%s:%#] %v";
+
+static LoggerInitializer _logger(env_file_var, env_level_var, log_pattern);
 
 int main() {
     // Test using tt-logger macros


### PR DESCRIPTION
Existing solution did not support FILE, and LINE info.

It also did not allow clients a way to configure the logging pattern in the initializer.

Fixing both things in this PR.