### PR TITLE
Add support for source location logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,26 @@
 cmake_minimum_required(VERSION 3.14)
 project(tt-logger VERSION 1.0.2 LANGUAGES CXX)
 
+# Set default C++17 when building tests, otherwise verify requirement
+if(TT_LOGGER_BUILD_TESTING AND NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+# Verify C++17 requirement since we use CTAD
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    message(
+        FATAL_ERROR
+        "tt-logger requires C++17, but CMAKE_CXX_STANDARD is not set"
+    )
+elseif(CMAKE_CXX_STANDARD LESS 17)
+    message(
+        FATAL_ERROR
+        "tt-logger requires at least C++17, but C++${CMAKE_CXX_STANDARD} was specified"
+    )
+endif()
+
 include(GNUInstallDirs)
 
 include(cmake/CPM.cmake)

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -5,6 +5,11 @@
 /**
  * @file tt-logger.hpp
  * @brief A logging utility header that provides type-safe logging functionality with different log levels and categories.
+ * @details This header provides a comprehensive logging system based on spdlog, with support for:
+ *          - Multiple log levels (trace, debug, info, warning, error, critical, fatal)
+ *          - Custom log categories/types for different components
+ *          - Type-safe formatting using fmt library
+ *          - Source location tracking
  */
 
 #pragma once
@@ -41,10 +46,28 @@
 namespace tt {
 
 /**
+ * @brief Gets the current source location information.
+ * @param file The source file name (automatically populated)
+ * @param line The source line number (automatically populated)
+ * @param function The function name (automatically populated)
+ * @return spdlog::source_loc The source location information
+ * @note Uses compiler-specific builtins when available for better accuracy
+ */
+constexpr spdlog::source_loc current_source_location(
+#if defined(__clang__) || defined(__GNUC__)
+    const char * file = __builtin_FILE(), int line = __builtin_LINE(), const char * function = __builtin_FUNCTION()
+#else
+    const char * file = __FILE__, int line = __LINE__, const char * function = __func__
+#endif
+        ) noexcept {
+    return spdlog::source_loc{ file, line, function };
+}
+
+/**
  * @brief Enumeration of different log categories/types supported by the logger.
- *
- * Each type represents a different component or subsystem that can be logged.
- * The types are defined using the TT_LOGGER_TYPES macro for easy extension.
+ * @details Each type represents a different component or subsystem that can be logged.
+ *          The types are defined using the TT_LOGGER_TYPES macro for easy extension.
+ *          Available types include: Always, Test, Timer, Device, LLRuntime, etc.
  */
 // clang-format off
 enum LogType {
@@ -56,9 +79,8 @@ enum LogType {
 
 /**
  * @brief Array containing string representations of all log types.
- *
- * The array is indexed by the LogType enum values and contains the corresponding
- * string names for each log type.
+ * @details The array is indexed by the LogType enum values and contains the corresponding
+ *          string names for each log type. Used internally for converting LogType to string.
  */
 constexpr std::array<const char *, std::size_t(LogType::LogEmulationDriver) + 1> log_type_names = {
 #define X(name) #name,
@@ -68,9 +90,8 @@ constexpr std::array<const char *, std::size_t(LogType::LogEmulationDriver) + 1>
 
 /**
  * @brief Converts a LogType enum value to its string representation.
- *
  * @param logtype The LogType enum value to convert
- * @return const char* The string representation of the log type
+ * @return const char* The string representation of the log type, or "UnknownType" if invalid
  */
 constexpr const char * logtype_to_string(LogType logtype) noexcept {
     return static_cast<std::size_t>(logtype) < log_type_names.size() ?
@@ -79,174 +100,173 @@ constexpr const char * logtype_to_string(LogType logtype) noexcept {
 }
 
 /**
- * @brief Logs a trace level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
+ * @brief Internal implementation of logging functionality.
+ * @tparam T Type of the first argument
+ * @tparam Rest Types of the remaining arguments
+ * @param loc Source location information
+ * @param level Log level to use
+ * @param first First argument (either LogType or format string)
+ * @param rest Remaining format arguments
+ * @details Handles the actual logging logic, supporting both direct logging and category-based logging
  */
-template <typename... Args> inline void log_trace(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    if (spdlog::should_log(spdlog::level::trace)) {
-        spdlog::trace("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+template <typename T, typename... Rest>
+static constexpr void log_impl(spdlog::source_loc loc, spdlog::level::level_enum level, T && first, Rest &&... rest) {
+    if constexpr (std::is_same_v<std::decay_t<T>, LogType>) {
+        if (spdlog::should_log(level)) {
+            if constexpr (sizeof...(Rest) > 0) {
+                spdlog::log(loc, level, "[{}] {}", first, fmt::format(std::forward<Rest>(rest)...));
+            } else {
+                spdlog::log(loc, level, "[{}]", first);
+            }
+        }
+    } else {
+        if (spdlog::should_log(level)) {
+            spdlog::log(loc, level, "[{}] {}", LogType::LogAlways,
+                        fmt::format(std::forward<T>(first), std::forward<Rest>(rest)...));
+        }
     }
 }
 
 /**
- * @brief Logs a trace level message with default LogAlways type.
- *
+ * @brief Logs a trace level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
  */
-template <typename... Args> inline void log_trace(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_trace(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs a debug level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_debug(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    if (spdlog::should_log(spdlog::level::debug)) {
-        spdlog::debug("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+template <typename... Args> struct log_trace {
+    constexpr log_trace(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::trace, std::forward<Args>(args)...);
+        }
     }
-}
+};
+
+// Deduction guide
+template <typename... Args> log_trace(Args &&...) -> log_trace<Args...>;
 
 /**
- * @brief Logs a debug level message with default LogAlways type.
- *
+ * @brief Logs a debug level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
  */
-template <typename... Args> inline void log_debug(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_debug(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
+template <typename... Args> struct log_debug {
+    constexpr log_debug(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::debug, std::forward<Args>(args)...);
+        }
+    }
+};
+
+// Deduction guide
+template <typename... Args> log_debug(Args &&...) -> log_debug<Args...>;
 
 /**
- * @brief Logs an info level message with a specific log type.
- *
+ * @brief Logs an info level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
  */
-template <typename... Args> inline void log_info(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::info("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
+template <typename... Args> struct log_info {
+    constexpr log_info(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::info, std::forward<Args>(args)...);
+        }
+    }
+};
+
+// Deduction guide
+template <typename... Args> log_info(Args &&...) -> log_info<Args...>;
 
 /**
- * @brief Logs an info level message with default LogAlways type.
- *
+ * @brief Logs a warning level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
  */
-template <typename... Args> inline void log_info(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_info(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
+template <typename... Args> struct log_warning {
+    constexpr log_warning(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::warn, std::forward<Args>(args)...);
+        }
+    }
+};
+
+// Deduction guide
+template <typename... Args> log_warning(Args &&...) -> log_warning<Args...>;
 
 /**
- * @brief Logs a warning level message with a specific log type.
- *
+ * @brief Logs an error level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
  */
-template <typename... Args> inline void log_warning(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::warn("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
+template <typename... Args> struct log_error {
+    constexpr log_error(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::err, std::forward<Args>(args)...);
+        }
+    }
+};
+
+// Deduction guide
+template <typename... Args> log_error(Args &&...) -> log_error<Args...>;
 
 /**
- * @brief Logs a warning level message with default LogAlways type.
- *
+ * @brief Logs a critical level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
  */
-template <typename... Args> inline void log_warning(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_warning(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
+template <typename... Args> struct log_critical {
+    constexpr log_critical(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::critical, std::forward<Args>(args)...);
+        }
+    }
+};
+
+// Deduction guide
+template <typename... Args> log_critical(Args &&...) -> log_critical<Args...>;
 
 /**
- * @brief Logs a critical level message with a specific log type.
- *
+ * @brief Logs a fatal level message.
  * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
+ * @param args Format string and arguments to log
+ * @param loc Source location information (automatically populated)
+ * @details Creates a temporary object that logs the message when constructed.
+ *          Supports both direct logging and category-based logging.
+ *          Note: Currently uses critical level internally.
  */
-template <typename... Args> inline void log_critical(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
+template <typename... Args> struct log_fatal {
+    constexpr log_fatal(Args &&... args, spdlog::source_loc loc = current_source_location()) noexcept {
+        if constexpr (sizeof...(Args) > 0) {
+            log_impl(loc, spdlog::level::critical, std::forward<Args>(args)...);
+        }
+    }
+};
 
-/**
- * @brief Logs a critical level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_critical(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_critical(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs a fatal level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_fatal(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs a fatal level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_fatal(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_fatal(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs an error level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_error(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::error("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs an error level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_error(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_error(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
+// Deduction guide
+template <typename... Args> log_fatal(Args &&...) -> log_fatal<Args...>;
 
 }  // namespace tt
 
 /**
  * @brief Custom formatter for tt::LogType to enable formatting in fmt library.
+ * @details Specializes fmt::formatter to allow LogType values to be formatted directly
+ *          in format strings using the string representation of the log type.
  */
 namespace fmt {
 template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -126,6 +126,16 @@ TEST_CASE("Basic logging functionality", "[logger]") {
         tt::log_critical(tt::LogOp, "Model critical error");
         soft_check_log_contains(sink.get(), "[Op] Model critical error");
     }
+
+    SECTION("Empty log_info") {
+        tt::log_info();
+        soft_check_log_contains(sink.get(), "");  // Should not log anything
+    }
+
+    SECTION("LogType only") {
+        tt::log_info(tt::LogMetal);
+        soft_check_log_contains(sink.get(), "[Metal]");  // Should log just the type without trailing space
+    }
 }
 
 TEST_CASE("Format string functionality", "[logger]") {


### PR DESCRIPTION
It was requested that we can log source location in #6.

To stay within the confines of "no macros" the only option is to use something like source_location and a default argument to capture the __FILE__ and __LINE__ information from the call site.

I had to follow the example discussed in: https://stackoverflow.com/questions/57547273/how-to-use-source-location-in-a-variadic-template-function

Additionally, because we also have a leading optional `LogType` parameter, extra complexity was introduced.

The code changes here seem to support what is desired without macros.


This PR is largely a rewrite, so I guess just look at this to understand the implementation.
https://github.com/tenstorrent/tt-logger/blob/84e86ac215b1614be3ccc08a4143d8e7b1b196a1/include/tt-logger/tt-logger.hpp#L112-L147