### PR TITLE
Add support for source location logging with macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A flexible and performant C++ logging library for Tenstorrent projects.
 - Optional category specification, defaults to `LogAlways`.
 - Efficient logging: Formatting cost is avoided for `trace` and `debug` messages if the level is disabled.
 - Header-only library for easy integration.
+- Macro-based implementation for automatic source location tracking.
 - Logging behavior can be customized, just as you would customize the default logger in spdlog.
 
 ## Log levels
@@ -83,22 +84,27 @@ cmake --install build
 
 int main() {
     // Log with different levels and categories
-    tt::log_info(tt::LogDevice, "Device message");
-    tt::log_debug(tt::LogOp, "Op debug message");
-    tt::log_warning(tt::LogLLRuntime, "Runtime warning");
-    tt::log_error(tt::LogDevice, "Device error");
-    tt::log_critical(tt::LogOp, "Op critical error");
+    log_info(tt::LogDevice, "Device message");
+    log_debug(tt::LogOp, "Op debug message");
+    log_warning(tt::LogLLRuntime, "Runtime warning");
+    log_error(tt::LogDevice, "Device error");
+    log_critical(tt::LogOp, "Op critical error");
 
     // Log with format strings
-    tt::log_info(tt::LogDevice, "Device {} message", 123);
-    tt::log_info(tt::LogOp, "Op {} with {} parameters", "test", 42);
+    log_info(tt::LogDevice, "Device {} message", 123);
+    log_info(tt::LogOp, "Op {} with {} parameters", "test", 42);
 
     // Log with default category (LogAlways)
-    tt::log_info("Default category message");
+    log_info("Default category message");
+
+    // Log with source location automatically included
+    log_error(tt::LogDevice, "Error occurred in function: {}", __func__);
 
     return 0;
 }
 ```
+
+The logging macros automatically include source location information (file, line number, and function name) in the log output. This is handled transparently by the macro implementation.
 
 ## Logger Initialization
 

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -78,19 +78,19 @@ constexpr const char * logtype_to_string(LogType logtype) noexcept {
                "UnknownType";
 }
 
-template <typename... Args> struct log_impl {
-    template <typename... T>
-    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, LogType type,
-             fmt::format_string<T...> fmt, T &&... args) {
+struct log_impl {
+    template <typename... Args>
+    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, tt::LogType type,
+             fmt::format_string<Args...> fmt, Args &&... args) {
         if (spdlog::should_log(level)) {
-            spdlog::log(loc, level, "[{}] {}", type, fmt::format(fmt, std::forward<T>(args)...));
+            spdlog::log(loc, level, "[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
         }
     }
 
-    template <typename... T>
-    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, fmt::format_string<T...> fmt,
-             T &&... args) :
-        log_impl(loc, level, LogType::LogAlways, fmt, std::forward<T>(args)...) {}
+    template <typename... Args>
+    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, fmt::format_string<Args...> fmt,
+             Args &&... args) :
+        log_impl(loc, level, tt::LogType::LogAlways, fmt, std::forward<Args>(args)...) {}
 };
 
 }  // namespace tt

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -78,7 +78,23 @@ constexpr const char * logtype_to_string(LogType logtype) noexcept {
                "UnknownType";
 }
 
+/**
+ * @brief Implementation struct for logging functionality.
+ *
+ * This struct provides the core implementation for logging with support for different log levels,
+ * log types, and formatted string output. It uses spdlog for the underlying logging mechanism.
+ */
 struct log_impl {
+    /**
+     * @brief Constructor for logging with a specific log type.
+     *
+     * @tparam Args Variadic template parameter for format arguments
+     * @param loc Source location information (file, line, function)
+     * @param level The log level (trace, debug, info, etc.)
+     * @param type The specific log type/category
+     * @param fmt Format string for the log message
+     * @param args Variadic arguments to be formatted into the message
+     */
     template <typename... Args>
     log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, tt::LogType type,
              fmt::format_string<Args...> fmt, Args &&... args) {
@@ -87,6 +103,15 @@ struct log_impl {
         }
     }
 
+    /**
+     * @brief Constructor for logging without a specific log type (uses LogAlways as default).
+     *
+     * @tparam Args Variadic template parameter for format arguments
+     * @param loc Source location information (file, line, function)
+     * @param level The log level (trace, debug, info, etc.)
+     * @param fmt Format string for the log message
+     * @param args Variadic arguments to be formatted into the message
+     */
     template <typename... Args>
     log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, fmt::format_string<Args...> fmt,
              Args &&... args) :
@@ -107,17 +132,94 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
 }  // namespace fmt
 #undef TT_LOGGER_TYPES
 
+/**
+ * @def log_trace(...)
+ * @brief Log a message at trace level.
+ *
+ * This macro logs a message with the lowest severity level, typically used for detailed
+ * debugging information. The message will include source file, line number, and function name.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ */
 #define log_trace(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::trace, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::trace, __VA_ARGS__)
+
+/**
+ * @def log_debug(...)
+ * @brief Log a message at debug level.
+ *
+ * This macro logs a message at debug level, used for debugging information that is
+ * more important than trace but less critical than info level.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ */
 #define log_debug(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::debug, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::debug, __VA_ARGS__)
+
+/**
+ * @def log_info(...)
+ * @brief Log a message at info level.
+ *
+ * This macro logs a message at info level, used for general informational messages
+ * about program execution.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ */
 #define log_info(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::info, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::info, __VA_ARGS__)
+
+/**
+ * @def log_warning(...)
+ * @brief Log a message at warning level.
+ *
+ * This macro logs a message at warning level, used for potentially harmful situations
+ * that don't prevent program execution.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ */
 #define log_warning(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::warn, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::warn, __VA_ARGS__)
+
+/**
+ * @def log_error(...)
+ * @brief Log a message at error level.
+ *
+ * This macro logs a message at error level, used for error events that might still
+ * allow the program to continue running.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ */
 #define log_error(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::err, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::err, __VA_ARGS__)
+
+/**
+ * @def log_critical(...)
+ * @brief Log a message at critical level.
+ *
+ * This macro logs a message at critical level, used for very severe error events
+ * that will likely lead to program termination.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ */
 #define log_critical(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)
+
+/**
+ * @def log_fatal(...)
+ * @brief Log a message at fatal level (alias for critical).
+ *
+ * This macro is an alias for log_critical, used for fatal errors that will
+ * lead to program termination.
+ *
+ * @param ... Format string and arguments to be logged
+ * @see log_impl
+ * @see log_critical
+ */
 #define log_fatal(...) \
-    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -116,6 +116,29 @@ struct log_impl {
     log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, fmt::format_string<Args...> fmt,
              Args &&... args) :
         log_impl(loc, level, tt::LogType::LogAlways, fmt, std::forward<Args>(args)...) {}
+
+    /**
+     * @brief Constructor for empty logging (no message).
+     *
+     * @param loc Source location information (file, line, function)
+     * @param level The log level (trace, debug, info, etc.)
+     */
+    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level) {
+        // Empty constructor - no logging
+    }
+
+    /**
+     * @brief Constructor for logging with only a log type.
+     *
+     * @param loc Source location information (file, line, function)
+     * @param level The log level (trace, debug, info, etc.)
+     * @param type The specific log type/category
+     */
+    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, tt::LogType type) {
+        if (spdlog::should_log(level)) {
+            spdlog::log(loc, level, "[{}]", type);
+        }
+    }
 };
 
 }  // namespace tt
@@ -143,7 +166,7 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_impl
  */
 #define log_trace(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::trace, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::trace, ##__VA_ARGS__)
 
 /**
  * @def log_debug(...)
@@ -156,7 +179,7 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_impl
  */
 #define log_debug(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::debug, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::debug, ##__VA_ARGS__)
 
 /**
  * @def log_info(...)
@@ -169,7 +192,7 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_impl
  */
 #define log_info(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::info, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::info, ##__VA_ARGS__)
 
 /**
  * @def log_warning(...)
@@ -182,7 +205,7 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_impl
  */
 #define log_warning(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::warn, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::warn, ##__VA_ARGS__)
 
 /**
  * @def log_error(...)
@@ -195,7 +218,7 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_impl
  */
 #define log_error(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::err, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::err, ##__VA_ARGS__)
 
 /**
  * @def log_critical(...)
@@ -208,7 +231,7 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_impl
  */
 #define log_critical(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, ##__VA_ARGS__)
 
 /**
  * @def log_fatal(...)
@@ -222,4 +245,4 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * @see log_critical
  */
 #define log_fatal(...) \
-    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)
+    ::tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, ##__VA_ARGS__)

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -78,170 +78,20 @@ constexpr const char * logtype_to_string(LogType logtype) noexcept {
                "UnknownType";
 }
 
-/**
- * @brief Logs a trace level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_trace(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    if (spdlog::should_log(spdlog::level::trace)) {
-        spdlog::trace("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
+template <typename... Args> struct log_impl {
+    template <typename... T>
+    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, LogType type,
+             fmt::format_string<T...> fmt, T &&... args) {
+        if (spdlog::should_log(level)) {
+            spdlog::log(loc, level, "[{}] {}", type, fmt::format(fmt, std::forward<T>(args)...));
+        }
     }
-}
 
-/**
- * @brief Logs a trace level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_trace(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_trace(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs a debug level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_debug(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    if (spdlog::should_log(spdlog::level::debug)) {
-        spdlog::debug("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-    }
-}
-
-/**
- * @brief Logs a debug level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_debug(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_debug(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs an info level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_info(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::info("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs an info level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_info(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_info(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs a warning level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_warning(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::warn("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs a warning level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_warning(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_warning(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs a critical level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_critical(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs a critical level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_critical(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_critical(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs a fatal level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_fatal(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::critical("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs a fatal level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_fatal(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_fatal(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
-
-/**
- * @brief Logs an error level message with a specific log type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param type The log type/category
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_error(LogType type, fmt::format_string<Args...> fmt, Args &&... args) {
-    spdlog::error("[{}] {}", type, fmt::format(fmt, std::forward<Args>(args)...));
-}
-
-/**
- * @brief Logs an error level message with default LogAlways type.
- *
- * @tparam Args Variadic template parameter for format arguments
- * @param fmt The format string
- * @param args The format arguments
- */
-template <typename... Args> inline void log_error(fmt::format_string<Args...> fmt, Args &&... args) {
-    log_error(LogType::LogAlways, fmt, std::forward<Args>(args)...);
-}
+    template <typename... T>
+    log_impl(const spdlog::source_loc & loc, spdlog::level::level_enum level, fmt::format_string<T...> fmt,
+             T &&... args) :
+        log_impl(loc, level, LogType::LogAlways, fmt, std::forward<T>(args)...) {}
+};
 
 }  // namespace tt
 
@@ -256,3 +106,18 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
 };
 }  // namespace fmt
 #undef TT_LOGGER_TYPES
+
+#define log_trace(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::trace, __VA_ARGS__)
+#define log_debug(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::debug, __VA_ARGS__)
+#define log_info(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::info, __VA_ARGS__)
+#define log_warning(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::warn, __VA_ARGS__)
+#define log_error(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::err, __VA_ARGS__)
+#define log_critical(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)
+#define log_fatal(...) \
+    tt::log_impl(spdlog::source_loc{ __FILE__, __LINE__, SPDLOG_FUNCTION }, spdlog::level::critical, __VA_ARGS__)

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -126,6 +126,16 @@ TEST_CASE("Basic logging functionality", "[logger]") {
         log_critical(tt::LogOp, "Model critical error");
         soft_check_log_contains(sink.get(), "[Op] Model critical error");
     }
+
+    SECTION("Empty log_info") {
+        log_info();
+        soft_check_log_contains(sink.get(), "");  // Should not log anything
+    }
+
+    SECTION("LogType only") {
+        log_info(tt::LogMetal);
+        soft_check_log_contains(sink.get(), "[Metal]");  // Should log just the type without trailing space
+    }
 }
 
 TEST_CASE("Format string functionality", "[logger]") {

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -29,8 +29,6 @@
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 
-using namespace tt;
-
 #define TT_LOGGER_TESTING
 
 // Custom sink to capture log output when TT_LOGGER_TESTING is defined
@@ -104,28 +102,28 @@ TEST_CASE("Basic logging functionality", "[logger]") {
     }
 
     SECTION("Info") {
-        log_info(LogDevice, "Device message");
+        log_info(tt::LogDevice, "Device message");
         soft_check_log_contains(sink.get(), "[Device] Device message");
     }
 
     SECTION("Debug") {
         spdlog::default_logger()->set_level(spdlog::level::debug);
-        log_debug(LogOp, "Model debug message");
+        log_debug(tt::LogOp, "Model debug message");
         soft_check_log_contains(sink.get(), "[Op] Model debug message");
     }
 
     SECTION("Warning") {
-        log_warning(LogLLRuntime, "Runtime warning");
+        log_warning(tt::LogLLRuntime, "Runtime warning");
         soft_check_log_contains(sink.get(), "[LLRuntime] Runtime warning");
     }
 
     SECTION("Error") {
-        log_error(LogDevice, "Device error");
+        log_error(tt::LogDevice, "Device error");
         soft_check_log_contains(sink.get(), "[Device] Device error");
     }
 
     SECTION("Critical") {
-        log_critical(LogOp, "Model critical error");
+        log_critical(tt::LogOp, "Model critical error");
         soft_check_log_contains(sink.get(), "[Op] Model critical error");
     }
 }
@@ -134,18 +132,18 @@ TEST_CASE("Format string functionality", "[logger]") {
     auto sink = setup_logger();
 
     SECTION("Single argument") {
-        log_info(LogDevice, "Device {} message", 123);
+        log_info(tt::LogDevice, "Device {} message", 123);
         soft_check_log_contains(sink.get(), "[Device] Device 123 message");
     }
 
     SECTION("Multiple arguments") {
-        log_info(LogOp, "Model {} with {} parameters", "test", 42);
+        log_info(tt::LogOp, "Model {} with {} parameters", "test", 42);
         soft_check_log_contains(sink.get(), "[Op] Model test with 42 parameters");
     }
 
     SECTION("Filesystem path formatting") {
         std::filesystem::path p = "/usr/bin/hello";
-        log_info(LogOp, "Path: {}", p);
+        log_info(tt::LogOp, "Path: {}", p);
         soft_check_log_contains(sink.get(), "[Op] Path: /usr/bin/hello");
     }
 }
@@ -157,8 +155,8 @@ TEST_CASE("Log level filtering", "[logger]") {
     SECTION("Debug filtering") {
         logger->set_level(spdlog::level::debug);
 
-        log_trace(LogDevice, "Should not appear");
-        log_debug(LogDevice, "Should appear");
+        log_trace(tt::LogDevice, "Should not appear");
+        log_debug(tt::LogDevice, "Should appear");
 
 #ifdef TT_LOGGER_TESTING
         auto output = get_output(sink.get());
@@ -174,8 +172,8 @@ TEST_CASE("Log level filtering", "[logger]") {
     SECTION("Info filtering") {
         logger->set_level(spdlog::level::info);
 
-        log_debug(LogDevice, "Should not appear");
-        log_info(LogDevice, "Should appear");
+        log_debug(tt::LogDevice, "Should not appear");
+        log_info(tt::LogDevice, "Should appear");
 
 #ifdef TT_LOGGER_TESTING
         auto output = get_output(sink.get());
@@ -190,9 +188,9 @@ TEST_CASE("Log level filtering", "[logger]") {
 }
 
 TEST_CASE("Log type to string mapping", "[logger]") {
-    REQUIRE(std::string(logtype_to_string(LogDevice)) == "Device");
-    REQUIRE(std::string(logtype_to_string(LogOp)) == "Op");
-    REQUIRE(std::string(logtype_to_string(LogLLRuntime)) == "LLRuntime");
+    REQUIRE(std::string(tt::logtype_to_string(tt::LogDevice)) == "Device");
+    REQUIRE(std::string(tt::logtype_to_string(tt::LogOp)) == "Op");
+    REQUIRE(std::string(tt::logtype_to_string(tt::LogLLRuntime)) == "LLRuntime");
 }
 
 TEST_CASE("Default log type behavior", "[logger]") {
@@ -215,9 +213,9 @@ TEST_CASE("File logging functionality", "[logger]") {
         spdlog::set_default_logger(logger);
 
         // Write some test logs
-        log_info(LogDevice, "Device file message");
-        log_warning(LogOp, "Model file warning");
-        log_error(LogLLRuntime, "Runtime file error");
+        log_info(tt::LogDevice, "Device file message");
+        log_warning(tt::LogOp, "Model file warning");
+        log_error(tt::LogLLRuntime, "Runtime file error");
 
         // Flush and close the logger
         logger->flush();
@@ -253,12 +251,12 @@ TEST_CASE("Performance testing", "[logger]") {
             logger->set_level(spdlog::level::info);
 
             // Test a single log first to verify setup
-            log_info(LogDevice, "Test setup message");
+            log_info(tt::LogDevice, "Test setup message");
 
             auto start = std::chrono::high_resolution_clock::now();
 
             for (int i = 0; i < num_iterations; ++i) {
-                log_info(LogDevice, "Performance test message {}", i);
+                log_info(tt::LogDevice, "Performance test message {}", i);
             }
 
             auto end      = std::chrono::high_resolution_clock::now();
@@ -287,12 +285,12 @@ TEST_CASE("Performance testing", "[logger]") {
             logger->set_level(spdlog::level::info);
 
             // Test a single log first to verify setup
-            log_debug(LogOp, "Test setup message");
+            log_debug(tt::LogOp, "Test setup message");
 
             auto start = std::chrono::high_resolution_clock::now();
 
             for (int i = 0; i < num_iterations; ++i) {
-                log_debug(LogOp, "Debug performance test message {}", i);
+                log_debug(tt::LogOp, "Debug performance test message {}", i);
             }
 
             auto end      = std::chrono::high_resolution_clock::now();

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -29,6 +29,8 @@
 #include <string>
 #include <tt-logger/tt-logger.hpp>
 
+using namespace tt;
+
 #define TT_LOGGER_TESTING
 
 // Custom sink to capture log output when TT_LOGGER_TESTING is defined
@@ -97,33 +99,33 @@ TEST_CASE("Basic logging functionality", "[logger]") {
     auto sink = setup_logger();
 
     SECTION("String literal") {
-        tt::log_info("This is a string literal");
+        log_info("This is a string literal");
         soft_check_log_contains(sink.get(), "[Always] This is a string literal");
     }
 
     SECTION("Info") {
-        tt::log_info(tt::LogDevice, "Device message");
+        log_info(LogDevice, "Device message");
         soft_check_log_contains(sink.get(), "[Device] Device message");
     }
 
     SECTION("Debug") {
         spdlog::default_logger()->set_level(spdlog::level::debug);
-        tt::log_debug(tt::LogOp, "Model debug message");
+        log_debug(LogOp, "Model debug message");
         soft_check_log_contains(sink.get(), "[Op] Model debug message");
     }
 
     SECTION("Warning") {
-        tt::log_warning(tt::LogLLRuntime, "Runtime warning");
+        log_warning(LogLLRuntime, "Runtime warning");
         soft_check_log_contains(sink.get(), "[LLRuntime] Runtime warning");
     }
 
     SECTION("Error") {
-        tt::log_error(tt::LogDevice, "Device error");
+        log_error(LogDevice, "Device error");
         soft_check_log_contains(sink.get(), "[Device] Device error");
     }
 
     SECTION("Critical") {
-        tt::log_critical(tt::LogOp, "Model critical error");
+        log_critical(LogOp, "Model critical error");
         soft_check_log_contains(sink.get(), "[Op] Model critical error");
     }
 }
@@ -132,18 +134,18 @@ TEST_CASE("Format string functionality", "[logger]") {
     auto sink = setup_logger();
 
     SECTION("Single argument") {
-        tt::log_info(tt::LogDevice, "Device {} message", 123);
+        log_info(LogDevice, "Device {} message", 123);
         soft_check_log_contains(sink.get(), "[Device] Device 123 message");
     }
 
     SECTION("Multiple arguments") {
-        tt::log_info(tt::LogOp, "Model {} with {} parameters", "test", 42);
+        log_info(LogOp, "Model {} with {} parameters", "test", 42);
         soft_check_log_contains(sink.get(), "[Op] Model test with 42 parameters");
     }
 
     SECTION("Filesystem path formatting") {
         std::filesystem::path p = "/usr/bin/hello";
-        tt::log_info(tt::LogOp, "Path: {}", p);
+        log_info(LogOp, "Path: {}", p);
         soft_check_log_contains(sink.get(), "[Op] Path: /usr/bin/hello");
     }
 }
@@ -155,8 +157,8 @@ TEST_CASE("Log level filtering", "[logger]") {
     SECTION("Debug filtering") {
         logger->set_level(spdlog::level::debug);
 
-        tt::log_trace(tt::LogDevice, "Should not appear");
-        tt::log_debug(tt::LogDevice, "Should appear");
+        log_trace(LogDevice, "Should not appear");
+        log_debug(LogDevice, "Should appear");
 
 #ifdef TT_LOGGER_TESTING
         auto output = get_output(sink.get());
@@ -172,8 +174,8 @@ TEST_CASE("Log level filtering", "[logger]") {
     SECTION("Info filtering") {
         logger->set_level(spdlog::level::info);
 
-        tt::log_debug(tt::LogDevice, "Should not appear");
-        tt::log_info(tt::LogDevice, "Should appear");
+        log_debug(LogDevice, "Should not appear");
+        log_info(LogDevice, "Should appear");
 
 #ifdef TT_LOGGER_TESTING
         auto output = get_output(sink.get());
@@ -188,16 +190,16 @@ TEST_CASE("Log level filtering", "[logger]") {
 }
 
 TEST_CASE("Log type to string mapping", "[logger]") {
-    REQUIRE(std::string(tt::logtype_to_string(tt::LogDevice)) == "Device");
-    REQUIRE(std::string(tt::logtype_to_string(tt::LogOp)) == "Op");
-    REQUIRE(std::string(tt::logtype_to_string(tt::LogLLRuntime)) == "LLRuntime");
+    REQUIRE(std::string(logtype_to_string(LogDevice)) == "Device");
+    REQUIRE(std::string(logtype_to_string(LogOp)) == "Op");
+    REQUIRE(std::string(logtype_to_string(LogLLRuntime)) == "LLRuntime");
 }
 
 TEST_CASE("Default log type behavior", "[logger]") {
     auto sink = setup_logger();
 
     SECTION("Defaults to LogAlways") {
-        tt::log_info("Default type message");
+        log_info("Default type message");
         soft_check_log_contains(sink.get(), "[Always] Default type message");
     }
 }
@@ -213,9 +215,9 @@ TEST_CASE("File logging functionality", "[logger]") {
         spdlog::set_default_logger(logger);
 
         // Write some test logs
-        tt::log_info(tt::LogDevice, "Device file message");
-        tt::log_warning(tt::LogOp, "Model file warning");
-        tt::log_error(tt::LogLLRuntime, "Runtime file error");
+        log_info(LogDevice, "Device file message");
+        log_warning(LogOp, "Model file warning");
+        log_error(LogLLRuntime, "Runtime file error");
 
         // Flush and close the logger
         logger->flush();
@@ -251,12 +253,12 @@ TEST_CASE("Performance testing", "[logger]") {
             logger->set_level(spdlog::level::info);
 
             // Test a single log first to verify setup
-            tt::log_info(tt::LogDevice, "Test setup message");
+            log_info(LogDevice, "Test setup message");
 
             auto start = std::chrono::high_resolution_clock::now();
 
             for (int i = 0; i < num_iterations; ++i) {
-                tt::log_info(tt::LogDevice, "Performance test message {}", i);
+                log_info(LogDevice, "Performance test message {}", i);
             }
 
             auto end      = std::chrono::high_resolution_clock::now();
@@ -285,12 +287,12 @@ TEST_CASE("Performance testing", "[logger]") {
             logger->set_level(spdlog::level::info);
 
             // Test a single log first to verify setup
-            tt::log_debug(tt::LogOp, "Test setup message");
+            log_debug(LogOp, "Test setup message");
 
             auto start = std::chrono::high_resolution_clock::now();
 
             for (int i = 0; i < num_iterations; ++i) {
-                tt::log_debug(tt::LogOp, "Debug performance test message {}", i);
+                log_debug(LogOp, "Debug performance test message {}", i);
             }
 
             auto end      = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
It was requested that we can log source location in https://github.com/tenstorrent/tt-logger/issues/6.