### PR TITLE
Simplify implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(tt-logger VERSION 1.0.2 LANGUAGES CXX)
+project(tt-logger VERSION 1.0.6 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,6 @@ int main() {
     log_info(tt::LogDevice, "Device {} message", 123);
     log_info(tt::LogOp, "Op {} with {} parameters", "test", 42);
 
-    // Log with default category (LogAlways)
-    log_info("Default category message");
-
     // Log with source location automatically included
     log_error(tt::LogDevice, "Error occurred in function: {}", __func__);
 
@@ -120,7 +117,7 @@ int main() {
     tt::LoggerInitializer logger_init;
 
     // Now you can use the logging functions
-    tt::log_info("Logger initialized");
+    tt::log_info(tt::LogAlways, "Logger initialized");
     return 0;
 }
 ```

--- a/tests/tt-logger-initializer-test.cpp
+++ b/tests/tt-logger-initializer-test.cpp
@@ -9,6 +9,8 @@
  * @note Requires setting the environment variable TT_METAL_LOGGER_LEVEL=debug before running
  */
 
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+
 #include <tt-logger/tt-logger-initializer.hpp>
 #include <tt-logger/tt-logger.hpp>
 

--- a/tests/tt-logger-initializer-test.cpp
+++ b/tests/tt-logger-initializer-test.cpp
@@ -23,12 +23,12 @@ static LoggerInitializer _logger(env_file_var, env_level_var, log_pattern);
 
 int main() {
     // Test using tt-logger macros
-    log_trace("This is a trace message");
-    log_debug("This is a debug message");
-    log_info("This is an info message");
-    log_warning("This is a warning message");
-    log_error("This is an error message");
-    log_critical("This is a critical message");
+    log_trace(LogAlways, "This is a trace message");
+    log_debug(LogAlways, "This is a debug message");
+    log_info(LogAlways, "This is an info message");
+    log_warning(LogAlways, "This is a warning message");
+    log_error(LogAlways, "This is an error message");
+    log_critical(LogAlways, "This is a critical message");
 
     return 0;
 }

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -171,7 +171,6 @@ TEST_CASE("Log level filtering", "[logger]") {
 
         log_trace(tt::LogDevice, "Should not appear");
         log_debug(tt::LogDevice, "Should appear");
-        log_info(tt::LogDevice, "Missing argument: {} {}", 1);
 
 #ifdef TT_LOGGER_TESTING
         auto output = get_output(sink.get());

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -16,6 +16,8 @@
  * The tests use Catch2 framework and include custom sink implementations for testing.
  */
 
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+
 #include <fmt/ranges.h>  // needed for container formatting
 #include <fmt/std.h>     // needed for filesystem::path formatting
 #include <spdlog/sinks/base_sink.h>


### PR DESCRIPTION
The initial implementation was macro based, just forwarding to spdlog.

I have gone back to that.

It is brain dead simple, it gives support for source location logging, and is the highest performance solution, as function calls can be optimized away when the current log level is not high enough to warrant logging.

Macros can be stripped away with `#define SPDLOG_ACTIVE_LEVEL`

Additionally, by using it with FMT_STRING, it can check arguments at compile time and avoid throwing exceptions.