### PR TITLE
Add Filtering Based on LogType

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(tt-logger VERSION 1.0.7 LANGUAGES CXX)
+project(tt-logger VERSION 1.0.8 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -14,6 +14,9 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -67,6 +70,8 @@ constexpr std::array<const char *, std::size_t(LogType::LogEmulationDriver) + 1>
 #undef X
 };
 
+static_assert(log_type_names.size() <= 64, "LogType bitmask only supports up to 64 log types");
+
 /**
  * @brief Converts a LogType enum value to its string representation.
  *
@@ -78,6 +83,63 @@ constexpr const char * logtype_to_string(LogType logtype) noexcept {
                log_type_names[static_cast<std::size_t>(logtype)] :
                "UnknownType";
 }
+
+/**
+ * @brief LogType filtering manager
+ *
+ * This class handles the filtering of log messages based on LogType using environment variables.
+ * It uses a bitmask approach similar to the old logger for efficient runtime filtering.
+ */
+class LogTypeFilter {
+  private:
+    std::uint64_t enabled_mask = (1ULL << LogAlways);  // Always enable LogAlways by default
+
+    LogTypeFilter() {
+        // Parse TT_LOGGER_TYPES environment variable
+        const char * types_env = std::getenv("TT_LOGGER_TYPES");
+        if (types_env) {
+            if (std::strstr(types_env, "All")) {
+                // Enable all log types
+                enabled_mask = 0xFFFFFFFFFFFFFFFFULL;
+            } else {
+                // Parse specific log types
+                enabled_mask             = 0;  // Start with none enabled
+                std::uint32_t type_index = 0;
+                for (const char * type_name : log_type_names) {
+                    if (std::strstr(types_env, type_name) != nullptr) {
+                        enabled_mask |= (1ULL << type_index);
+                    }
+                    type_index++;
+                }
+                // Always ensure LogAlways is enabled
+                enabled_mask |= (1ULL << LogAlways);
+            }
+        }
+        // If no environment variable is set, default to all types enabled
+        else {
+            enabled_mask = 0xFFFFFFFFFFFFFFFFULL;
+        }
+    }
+
+  public:
+    /**
+     * @brief Get the singleton instance of LogTypeFilter
+     * @return Reference to the LogTypeFilter instance
+     */
+    static LogTypeFilter & get() {
+        static LogTypeFilter instance;
+        return instance;
+    }
+
+    /**
+     * @brief Check if a specific LogType is enabled for logging
+     * @param logtype The LogType to check
+     * @return true if the LogType is enabled, false otherwise
+     */
+    bool log(LogType logtype) const noexcept {
+        return (enabled_mask & (1ULL << static_cast<std::uint32_t>(logtype))) != 0;
+    }
+};
 
 }  // namespace tt
 
@@ -94,13 +156,19 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
 #undef TT_LOGGER_TYPES
 
 /**
- * @brief Logging macros for different severity levels
+ * @brief Logging macros for different severity levels with LogType filtering
  *
  * These macros provide type-safe logging functionality with different severity levels.
+ * They include runtime filtering based on LogType using environment variables.
  * Each macro takes the following parameters:
  * @param type The log type/category for the message (e.g., LogDevice, LogOp)
  * @param fmt Format string for the log message
  * @param ... Variadic arguments to be formatted into the message
+ *
+ * Environment Variables:
+ * - TT_LOGGER_TYPES: Comma-separated list of log types to enable (e.g., "Device,Op") or "All"
+ * - TT_LOGGER_LEVEL: Log level (trace, debug, info, warning, error, critical)
+ * - TT_LOGGER_FILE: Path to log file (if not set, logs to stdout)
  *
  * Available macros:
  * - log_trace: Very detailed debug info, useful for tracing program flow
@@ -111,10 +179,59 @@ template <> struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
  * - log_critical: Severe error, program may not continue safely
  * - log_fatal: Alias for log_critical
  */
-#define log_trace(type, fmt, ...)    SPDLOG_TRACE(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
-#define log_debug(type, fmt, ...)    SPDLOG_DEBUG(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
-#define log_info(type, fmt, ...)     SPDLOG_INFO(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
-#define log_warning(type, fmt, ...)  SPDLOG_WARN(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
-#define log_error(type, fmt, ...)    SPDLOG_ERROR(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
-#define log_critical(type, fmt, ...) SPDLOG_CRITICAL(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
-#define log_fatal(type, fmt, ...)    SPDLOG_CRITICAL(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#ifdef NDEBUG
+
+#    define log_trace(type, fmt, ...)    SPDLOG_TRACE(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#    define log_debug(type, fmt, ...)    SPDLOG_DEBUG(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#    define log_info(type, fmt, ...)     SPDLOG_INFO(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#    define log_warning(type, fmt, ...)  SPDLOG_WARN(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#    define log_error(type, fmt, ...)    SPDLOG_ERROR(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#    define log_critical(type, fmt, ...) SPDLOG_CRITICAL(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+#    define log_fatal(type, fmt, ...)    SPDLOG_CRITICAL(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__)
+
+#else
+
+#    define log_trace(type, fmt, ...)                                       \
+        do {                                                                \
+            if (tt::LogTypeFilter::get().log(type)) {                       \
+                SPDLOG_TRACE(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                               \
+        } while (0)
+#    define log_debug(type, fmt, ...)                                       \
+        do {                                                                \
+            if (tt::LogTypeFilter::get().log(type)) {                       \
+                SPDLOG_DEBUG(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                               \
+        } while (0)
+#    define log_info(type, fmt, ...)                                       \
+        do {                                                               \
+            if (tt::LogTypeFilter::get().log(type)) {                      \
+                SPDLOG_INFO(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                              \
+        } while (0)
+#    define log_warning(type, fmt, ...)                                    \
+        do {                                                               \
+            if (tt::LogTypeFilter::get().log(type)) {                      \
+                SPDLOG_WARN(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                              \
+        } while (0)
+#    define log_error(type, fmt, ...)                                       \
+        do {                                                                \
+            if (tt::LogTypeFilter::get().log(type)) {                       \
+                SPDLOG_ERROR(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                               \
+        } while (0)
+#    define log_critical(type, fmt, ...)                                       \
+        do {                                                                   \
+            if (tt::LogTypeFilter::get().log(type)) {                          \
+                SPDLOG_CRITICAL(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                                  \
+        } while (0)
+#    define log_fatal(type, fmt, ...)                                          \
+        do {                                                                   \
+            if (tt::LogTypeFilter::get().log(type)) {                          \
+                SPDLOG_CRITICAL(FMT_STRING("[{}] " fmt), type, ##__VA_ARGS__); \
+            }                                                                  \
+        } while (0)
+
+#endif


### PR DESCRIPTION
Closes #17 

If this is not Release build, then enable LogType filtering at runtime.

Developers can filter the log messages by using `TT_LOGGER_TYPES="Device;Op"` to get only Device and Op logs.