### PR TITLE
Change from Meyer's Singleton to Infinite Singleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(tt-logger VERSION 1.1.4 LANGUAGES CXX)
+project(tt-logger VERSION 1.1.5 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -212,8 +212,8 @@ class LoggerRegistry {
 
   public:
     static LoggerRegistry & instance() {
-        static LoggerRegistry registry;
-        return registry;
+        static LoggerRegistry * registry = new LoggerRegistry();
+        return *registry;
     }
 
     std::shared_ptr<spdlog::logger> get(LogType type) { return loggers[static_cast<std::size_t>(type)]; }


### PR DESCRIPTION
People have reported issues with dead singleton access.

There must be a static destruction order problem created by multiple singletons in the code base.

Since this is a logger, and it won't allocate hardware resources, it is okay to use the infinite singleton pattern, and rely on the OS to free the memory after process termination.