### PR TITLE
Add LogUMD instead of LogSiliconDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The following log categories are available:
 - TTNN
 - MetalTrace
 - Inspector
-- SiliconDriver
+- UMD
 - EmulationDriver
 
 Each category is prefixed with "Log" when used in code (e.g., `tt::LogDevice`, `tt::LogOp`, `tt::LogInspector`).
@@ -176,7 +176,7 @@ The `TT_LOGGER_TYPES` environment variable allows you to filter which log catego
 export TT_LOGGER_TYPES="Metal;TTNN"
 
 # Show all device-related logs
-export TT_LOGGER_TYPES="Device;SiliconDriver;EmulationDriver"
+export TT_LOGGER_TYPES="Device;UMD;EmulationDriver"
 ```
 
 ## Compile-time Log Level Control

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -43,7 +43,7 @@
     X(TTNN)             \
     X(MetalTrace)       \
     X(Inspector)        \
-    X(SiliconDriver)    \
+    X(UMD)              \
     X(EmulationDriver)
 
 namespace tt {

--- a/tests/tt-logger-test.cpp
+++ b/tests/tt-logger-test.cpp
@@ -59,7 +59,7 @@ int main() {
     std::set<int>    chip_ids = { 1, 2, 3 };
     std::vector<int> pci_ids  = { 4096, 8192, 12288 };
 
-    log_info(tt::LogSiliconDriver, "Opening chip ids: {} with pci ids: {}", chip_ids, pci_ids);
+    log_info(tt::LogUMD, "Opening chip ids: {} with pci ids: {}", chip_ids, pci_ids);
 
     std::cout << std::endl;
 
@@ -75,9 +75,9 @@ int main() {
 
     // Test 5: Log type to string mapping
     std::cout << "Test 5: Log type to string mapping" << std::endl;
-    std::cout << "Expected: Device, Op, LLRuntime, SiliconDriver" << std::endl;
+    std::cout << "Expected: Device, Op, LLRuntime, UMD" << std::endl;
     std::cout << "Actual output: " << tt::logtype_to_string(tt::LogDevice) << ", " << tt::logtype_to_string(tt::LogOp)
-              << ", " << tt::logtype_to_string(tt::LogLLRuntime) << ", " << tt::logtype_to_string(tt::LogSiliconDriver)
+              << ", " << tt::logtype_to_string(tt::LogLLRuntime) << ", " << tt::logtype_to_string(tt::LogUMD)
               << std::endl;
 
     std::cout << std::endl;


### PR DESCRIPTION
Add LogUMD instead of LogSiliconDriver. SiliconDriver is a class that has been deleted for quite some time in UMD so we would like to switch logging print as well