### PR TITLE
Use compiled spdlog by default for faster consumer build times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,19 @@
 cmake_minimum_required(VERSION 3.14)
-project(tt-logger VERSION 1.1.7 LANGUAGES CXX)
+project(tt-logger VERSION 1.1.8 LANGUAGES CXX)
 
 include(GNUInstallDirs)
+
+option(TT_LOGGER_SPDLOG_HEADER_ONLY
+    "Use spdlog in header-only mode. When OFF (default), links against the compiled spdlog library for significantly faster build times."
+    OFF
+)
 
 include(cmake/CPM.cmake)
 if(NOT TARGET fmt::fmt-header-only)
     cpmaddpackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
 endif()
 
-if(NOT TARGET spdlog::spdlog_header_only)
+if(NOT TARGET spdlog::spdlog)
     cpmaddpackage(
         NAME spdlog
         GITHUB_REPOSITORY gabime/spdlog
@@ -18,6 +23,13 @@ if(NOT TARGET spdlog::spdlog_header_only)
             "SPDLOG_INSTALL ON"
     )
 endif()
+
+if(TT_LOGGER_SPDLOG_HEADER_ONLY)
+    set(_tt_logger_spdlog_target spdlog::spdlog_header_only)
+else()
+    set(_tt_logger_spdlog_target spdlog::spdlog)
+endif()
+message(STATUS "tt-logger: using spdlog target ${_tt_logger_spdlog_target}")
 
 # Header-only library
 add_library(${PROJECT_NAME} INTERFACE)
@@ -48,7 +60,7 @@ endif()
 
 target_link_libraries(
     ${PROJECT_NAME}
-    INTERFACE spdlog::spdlog_header_only fmt::fmt-header-only
+    INTERFACE ${_tt_logger_spdlog_target} fmt::fmt-header-only
 )
 
 option(TT_LOGGER_INSTALL "Configure for installation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT TARGET fmt::fmt-header-only)
     cpmaddpackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
 endif()
 
-if(NOT TARGET spdlog::spdlog)
+if(NOT TARGET spdlog::spdlog AND NOT TARGET spdlog::spdlog_header_only)
     cpmaddpackage(
         NAME spdlog
         GITHUB_REPOSITORY gabime/spdlog


### PR DESCRIPTION
## Summary

Switch the default spdlog linkage from header-only (`spdlog::spdlog_header_only`) to compiled (`spdlog::spdlog`). This eliminates redundant template instantiations of spdlog's `pattern_formatter::handle_flag_<>` in every translation unit that includes tt-logger.

A new CMake option `TT_LOGGER_SPDLOG_HEADER_ONLY` (default `OFF`) is provided to restore the previous header-only behavior if needed.

## What changed

- **Default**: tt-logger now links against `spdlog::spdlog` (compiled library)
- **Option**: Set `TT_LOGGER_SPDLOG_HEADER_ONLY=ON` to get the old header-only behavior
- **Version**: Bumped to 1.1.8

## Why

When spdlog is used header-only, every translation unit that includes tt-logger pays the cost of:
- Parsing 1,340 lines of `pattern_formatter-inl.h`
- Instantiating `handle_flag_<scoped_padder>` and `handle_flag_<null_scoped_padder>` — a massive template with a ~30-case switch statement creating `unique_ptr`s for every formatter type

With the compiled library, these implementations are compiled once into `libspdlog.a` (or `.so`) and linked at the end.

## Measured impact on tt-metal

Profiled with `ClangBuildAnalyzer` (clang-20, Unity builds + PCH enabled):

| Metric | Before | After | Savings |
|--------|--------|-------|---------|
| Parsing (frontend) | 13,414s | 9,532s | **-3,883s (29%)** |
| Codegen (backend) | 12,414s | 7,519s | **-4,895s (39%)** |
| **Total** | **25,828s** | **17,051s** | **-8,778s (34%)** |

`spdlog::pattern_formatter::handle_flag_<>` was previously the #1 most expensive template instantiation at **1,312 seconds** across 838 instantiations. It is completely eliminated from consumer builds.

## Consumer usage

No changes needed for consumers that already have spdlog added via CPM — the compiled `spdlog::spdlog` target is always created alongside `spdlog::spdlog_header_only`. Consumers just need to ensure `BUILD_SHARED_LIBS=OFF` for the spdlog package if they want static linkage (no extra `.so` to ship).

To opt back into header-only mode:
```cmake
CPMAddPackage(
    NAME tt-logger
    ...
    OPTIONS "TT_LOGGER_SPDLOG_HEADER_ONLY ON"
)
```