### PR TITLE
Fix installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
         INTERFACE
             FILE_SET api
             TYPE HEADERS
-            BASE_DIRS ${CMAKE_INSTALL_INCLUDEDIR}
-            FILES ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/tt-logger.hpp
+            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+            FILES
+                include/${PROJECT_NAME}/tt-logger.hpp
     )
 endif()
 


### PR DESCRIPTION
Fixes this installation error:
```
install flags: -j128 install
[0/1] Install the project...
-- Install configuration: "Release"
CMake Error at cmake_install.cmake:54 (file):
  file INSTALL cannot find
  "/nix/store/j16v9n4r250qnmlkzbf6qz8cv0zv54sl-tt-logger-1.1.8/include/tt-logger/tt-logger.hpp":
  No such file or directory.


FAILED: [code=1] CMakeFiles/install.util
cd /build/source/build && /nix/store/jzkw4x0b77fv2il53vpp6fylc09a6p75-cmake-4.1.2/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```