### PR TITLE
Add LogFabricManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(tt-logger VERSION 1.2.0 LANGUAGES CXX)
+project(tt-logger VERSION 1.1.9 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(tt-logger VERSION 1.1.8 LANGUAGES CXX)
+project(tt-logger VERSION 1.2.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following log categories are available:
 - Op
 - Dispatch
 - Fabric
+- FabricManager
 - Metal
 - TTNN
 - MetalTrace

--- a/include/tt-logger/tt-logger.hpp
+++ b/include/tt-logger/tt-logger.hpp
@@ -39,6 +39,7 @@
     X(Op)               \
     X(Dispatch)         \
     X(Fabric)           \
+    X(FabricManager)    \
     X(Metal)            \
     X(TTNN)             \
     X(MetalTrace)       \


### PR DESCRIPTION
Add a log tag to be used by fabric manager and potentially in tt-metal to log info related to fabric recovery actions.